### PR TITLE
expose parameters via config-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Recommended way:
 (cfg/def nakadi-url {:required true})
 (cfg/def subscription-id {:required true})
 (cfg/def access-token {:required true})
+(cfg/def batch-limit)
 
 
 (m/defstate client
@@ -46,7 +47,7 @@ Recommended way:
 
 (m/defstate consumer
   :start (do
-           (nakadi/consume-subscription @client subscription-id callback)
+           (nakadi/consume-subscription @client {:subscription-id subscription-id :batch-limit batch-limit} callback)
            ;(nakadi/consume-raw-events @client "foobar.event" callback)
            )
   :stop (time (@consumer)))
@@ -57,6 +58,19 @@ Recommended way:
   (nakadi/publish-events @client "foobar.event" (for [i (range 10)]
                                                       {:x i})))
 ```
+
+Currently, the following stream parameters are supported:
+
+
+| parameter                | type | description                                                                                                                                                   | required |           default |
+| ---                      | ---  | ---                                                                                                                                                           | ---      |               --- |
+| :subscription-id         | int  |                                                                                                                                                               | true     |                   |
+| :batch-limit             | int  | Maximum number of Events in each batch of the stream                                                                                                          | false    |                 1 |
+| :max-retry-attempts      | int  |                                                                                                                                                               | false    | Integer.MAX_VALUE |
+| :max-uncommited-events   | int  |                                                                                                                                                               | false    |                10 |
+| :stream-keep-alive-limit | int  | Set the maximum number of empty keep alive batches to get in a row before closing. If 0 or undefined will send keep alive messages indefinitely.              | false    |                 0 |
+| :stream-limit            | ini  | Set the maximum number of Events in this stream (over all partitions being streamed in this connection). If 0 or undefined, will stream batches indefinitely. | false    |                 0 |
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Recommended way:
 
 (m/defstate consumer
   :start (do
-           (nakadi/consume-subscription @client (nakadi/->subscription-stream-config {:subscription-id subscription-id :batch-limit batch-limit}) callback)
+           (nakadi/consume-subscription @client subscription-id callback)
+           ;(nakadi/consume-subscription @client {:subscription-id subscription-id :batch-limit batch-limit} callback)
            ;(nakadi/consume-subscription @client stream-config callback)
            ;(nakadi/consume-raw-events @client "foobar.event" callback)
            )

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Recommended way:
 
 (m/defstate consumer
   :start (do
-           (nakadi/consume-subscription @client {:subscription-id subscription-id :batch-limit batch-limit} callback)
+           (nakadi/consume-subscription @client (nakadi/->subscription-stream-config {:subscription-id subscription-id :batch-limit batch-limit}) callback)
+           ;(nakadi/consume-subscription @client stream-config callback)
            ;(nakadi/consume-raw-events @client "foobar.event" callback)
            )
   :stop (time (@consumer)))
@@ -58,20 +59,6 @@ Recommended way:
   (nakadi/publish-events @client "foobar.event" (for [i (range 10)]
                                                       {:x i})))
 ```
-
-Currently, the following stream parameters are supported:
-
-
-| parameter                | type | description                                                                                                                                                   | required |           default |
-| ---                      | ---  | ---                                                                                                                                                           | ---      |               --- |
-| :subscription-id         | int  |                                                                                                                                                               | true     |                   |
-| :batch-limit             | int  | Maximum number of Events in each batch of the stream                                                                                                          | false    |                 1 |
-| :max-retry-attempts      | int  |                                                                                                                                                               | false    | Integer.MAX_VALUE |
-| :max-uncommited-events   | int  |                                                                                                                                                               | false    |                10 |
-| :stream-keep-alive-limit | int  | Set the maximum number of empty keep alive batches to get in a row before closing. If 0 or undefined will send keep alive messages indefinitely.              | false    |                 0 |
-| :stream-limit            | ini  | Set the maximum number of Events in this stream (over all partitions being streamed in this connection). If 0 or undefined, will stream batches indefinitely. | false    |                 0 |
-
-
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject me.dryewo/clj-nakadi-java "0.0.3"
+(defproject me.dryewo/clj-nakadi-java "0.0.2"
   :description "Nakadi client in Clojure. Thin wrapper around nakadi-java."
   :url "http://github.com/dryewo/clj-nakadi-java"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject me.dryewo/clj-nakadi-java "0.0.2"
+(defproject me.dryewo/clj-nakadi-java "0.0.3"
   :description "Nakadi client in Clojure. Thin wrapper around nakadi-java."
   :url "http://github.com/dryewo/clj-nakadi-java"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
So far the subscription-id was the only accepted parameter.  With this PR we can configure the stream by supplying a configuration map to `consume-subscription`.